### PR TITLE
Fix Windows multicast socket binding error (WSAEADDRNOTAVAILABLE)

### DIFF
--- a/examples/demo/demo.rs
+++ b/examples/demo/demo.rs
@@ -44,7 +44,12 @@ fn main() -> io::Result<()> {
     let recv_socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
     recv_socket.set_reuse_address(true)?;
     recv_socket.set_nonblocking(true)?;
+
+    #[cfg(not(windows))]
     recv_socket.bind(&SocketAddrV4::new(multicast_address, port).into())?;
+
+    #[cfg(windows)]
+    recv_socket.bind(&SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port).into())?;
 
     loop {
         match state {


### PR DESCRIPTION
## PR Description:
Fixes Windows demo crash with "The requested address is not valid in its context" error.

###  Problem:
The demo binds directly to multicast address `224.0.0.180:4809`. This works on Linux/macOS but fails on Windows with error `10049 (WSAEADDRNOTAVAILABLE)`.

### Root cause:
- Linux/macOS: Allow binding to multicast addresses and handle multiple processes correctly
- Windows: Prohibits binding to multicast addresses, requires binding to local interface

### Solution:
Platform-specific binding:
- Windows: Bind to 0.0.0.0:4809 (any interface)
- Linux/macOS: Keep original 224.0.0.180:4809 (preserves multi-process behavior)

The `join_multicast_v4()` call handles actual multicast subscription on all platforms.